### PR TITLE
Hardened macros

### DIFF
--- a/main.c
+++ b/main.c
@@ -44,11 +44,11 @@ static void* KERNAL_ISR_HANDLER;
     __asm__ ("pla");                                \
     __asm__ ("jmp (_KERNAL_ISR_HANDLER)")
 
-#define vera_vset(addr) VERA.address = (addr) & 0xffff; VERA.address_hi = (((addr) | VERA_AUTO_INC_1) >> 16)
+#define vera_vset(addr) do { VERA.address = (addr) & 0xffff; VERA.address_hi = (((addr) | VERA_AUTO_INC_1) >> 16); } while(0)
 
-#define vera_write8(data) VERA.data0 = data
+#define vera_write8(data) do { VERA.data0 = (data); } while(0)
 
-#define vera_write16(data) VERA.data0 = data & 0xff; VERA.data0 = data >> 8;
+#define vera_write16(data) do { VERA.data0 = (data) & 0xff; VERA.data0 = (data) >> 8; } while(0)
 
 static void vera_write(const uint8_t* src, uint16_t num)
 {


### PR DESCRIPTION
Small C pro advice with your vera macros. Pack the expression inside a do { } while(0). Also pack the macro parameter ALWAYS inside parenthesis.
Example: your #define vera_write16(data) VERA.data0 = data & 0xff; VERA.data0 = data >> 8;

Imagine what happens if you write if(x) vera_write(x & 1);
Only the first statement will be execute conditionally, the second will always be executed. Further your second value will always write 0 as x & 1 >> 8 will be evaluated as x & (1 >> 8))
So write your macro this way

#define vera_write16(data) do { VERA.data0 = (data) & 0xff; VERA.data0 = (data) >> 8; } while(0)